### PR TITLE
Add `resolve` convenience method

### DIFF
--- a/PeakOperation/MapOperation.swift
+++ b/PeakOperation/MapOperation.swift
@@ -38,3 +38,33 @@ open class MapOperation<Input, Output>: ConcurrentOperation, ProducesResult, Con
         finish()
     }
 }
+
+/// An operation which takes an Input and maps it to an Output.
+///
+/// When chaining operations, you may wish to pass the result of one to another, but the types do not match.
+/// By inserting a MapOperation between them, you can perform a mapping of the Output type to the Input type.
+///
+/// This operation only passes successful inputs to the provided block. An error input is cascaded down (set as the output).
+open class MapSuccessOperation<Input, Output>: ConcurrentOperation, ProducesResult, ConsumesResult {
+    
+    /// The result to be mapped.
+    public var input: Result<Input> = Result { throw ResultError.noResult }
+    
+    /// The mapped result.
+    public var output: Result<Output> = Result { throw ResultError.noResult }
+    
+    let block: (Input) -> (Output)
+
+    /// Create a new `MapSuccessOperation`.
+    ///
+    /// - Parameter block: A block which takes a Result of type `Input` and maps it to one with type `Output`.
+    public init(_ block: @escaping (Input) -> (Output)) {
+        self.block = block
+    }
+    
+    /// :nodoc:
+    open override func execute() {
+        output = resolve { from in Result { self.block(from) } }
+        finish()
+    }
+}

--- a/PeakOperation/UsingResult.swift
+++ b/PeakOperation/UsingResult.swift
@@ -76,3 +76,21 @@ extension ProducesResult where Self: ConcurrentOperation {
         return operation
     }
 }
+
+
+extension ConsumesResult where Self: ProducesResult {
+    
+    /// Resolves the input to the object.
+    /// If the input is `.success`, calls the provided block with it as its argument and returns a new result.
+    /// If the input is `.failure`, the error is passed along and returns a new result containing the error.
+    ///
+    /// - Parameter block: A block which takes the input and transforms it into an output Result.
+    /// - Returns: If the input is `.success`, the result of calling the provided block. If the input is `.failure`, a result containing the error.
+    public func resolve(_ block: @escaping (Input) -> Result<Output>) -> Result<Output> {
+        do {
+            return block(try input.resolve())
+        } catch {
+            return Result { throw error }
+        }
+    }
+}

--- a/PeakOperationTests/PeakOperationTests.swift
+++ b/PeakOperationTests/PeakOperationTests.swift
@@ -119,6 +119,41 @@ class PeakOperationTests: XCTestCase {
         XCTAssertEqual(op1.operationChain, [op1])
     }
     
+    func testMapSuccessOperationPassesSuccess() {
+        let expect = expectation(description: "")
+
+        let operation = MapSuccessOperation<Bool, Bool> { input in !input }
+        operation.input = Result { true }
+        
+        operation.addResultBlock { result in
+            XCTAssertFalse(try! result.resolve())
+            expect.fulfill()
+        }
+        
+        operation.enqueue()
+        waitForExpectations(timeout: 1)
+    }
+    
+    func testMapSuccessOperationPassesError() {
+        let expect = expectation(description: "")
+        
+        let operation = MapSuccessOperation<Bool, Bool> { input in !input }
+        operation.input = Result { throw TestError.justATest }
+        
+        operation.addResultBlock { result in
+            do {
+                let _ = try result.resolve()
+                XCTFail()
+            } catch {
+                expect.fulfill()
+            }
+        }
+        
+        operation.enqueue()
+        waitForExpectations(timeout: 1)
+    }
+
+    
     func testManyOperationsRecursiveDependencies() {
         let op1 = MapOperation<Bool, Bool> { _ in
             return Result { return false }
@@ -451,5 +486,3 @@ open class TestRetryOperation: RetryingOperation<AnyObject> {
         finish()
     }
 }
-
-

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - PeakResult (2.1.0)
+  - PeakResult (2.1.1)
 
 DEPENDENCIES:
   - PeakResult
 
 SPEC REPOS:
-  "git@gitlab.3squared.com:iOSLibraries/CocoaPodSpecs.git":
+  https://github.com/cocoapods/specs.git:
     - PeakResult
 
 SPEC CHECKSUMS:
-  PeakResult: 4b8d79159f0bb20dc9715c73fd4ed642c15a24ea
+  PeakResult: a3bbeaae2485fec1199a09f6991a7b8613a9d6ed
 
-PODFILE CHECKSUM: 5ce11dae6614af9227932c0c2c5e2773f5124f4c
+PODFILE CHECKSUM: 847853bfed1b672d2a64d8867c3c89d5c7a18982
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Add `resolve` convenience method to objects that implement both consume and produce result

Aims to eliminate some boilerplate by forwarding on errors and allowing the caller to only consider the success case in a chained set of operations.