### PR TITLE
 Add notifications that are posted on start/finish of an operation

### DIFF
--- a/PeakOperation.xcodeproj/project.pbxproj
+++ b/PeakOperation.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		1864BE8221998F54004E5436 /* PeakOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = CB4C115F1DF9800600837343 /* PeakOperation.h */; };
 		18D0B5B020FCE6E200CD77F6 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18D0B5AF20FCE6E200CD77F6 /* ResultTests.swift */; };
 		8D1A2D781E951E2F001EF435 /* ConcurrentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1A2D771E951E2F001EF435 /* ConcurrentOperation.swift */; };
+		CB0C195E225F7E35004ECDD1 /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0C195D225F7E35004ECDD1 /* NotificationTests.swift */; };
 		CB3178711FD7FE9800B063ED /* GroupChainOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3178701FD7FE9800B063ED /* GroupChainOperation.swift */; };
 		CB47513E1E3A4AA500A43672 /* Operation+Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB47513D1E3A4AA500A43672 /* Operation+Queue.swift */; };
 		CB4C11661DF9800600837343 /* PeakOperation_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4C115C1DF9800600837343 /* PeakOperation_iOS.framework */; };
@@ -57,6 +58,7 @@
 		1864BE7321998B79004E5436 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		18D0B5AF20FCE6E200CD77F6 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		8D1A2D771E951E2F001EF435 /* ConcurrentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentOperation.swift; sourceTree = "<group>"; };
+		CB0C195D225F7E35004ECDD1 /* NotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTests.swift; sourceTree = "<group>"; };
 		CB3178701FD7FE9800B063ED /* GroupChainOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupChainOperation.swift; sourceTree = "<group>"; };
 		CB47513D1E3A4AA500A43672 /* Operation+Queue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Operation+Queue.swift"; sourceTree = "<group>"; };
 		CB4C115C1DF9800600837343 /* PeakOperation_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PeakOperation_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -133,6 +135,7 @@
 				CB55BB582226A7C1000A0E17 /* GroupTests.swift */,
 				CB55BB5A2226A7F3000A0E17 /* MapTests.swift */,
 				CB55BB5C2226A849000A0E17 /* RetryTests.swift */,
+				CB0C195D225F7E35004ECDD1 /* NotificationTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -447,6 +450,7 @@
 				CB55BB592226A7C1000A0E17 /* GroupTests.swift in Sources */,
 				CB55BB5B2226A7F3000A0E17 /* MapTests.swift in Sources */,
 				18D0B5B020FCE6E200CD77F6 /* ResultTests.swift in Sources */,
+				CB0C195E225F7E35004ECDD1 /* NotificationTests.swift in Sources */,
 				CB55BB5D2226A849000A0E17 /* RetryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PeakOperation/Core/ConcurrentOperation.swift
+++ b/PeakOperation/Core/ConcurrentOperation.swift
@@ -119,9 +119,6 @@ open class ConcurrentOperation: Operation {
     
     private func postNotification(_ notification: Notification.Name) {
         var userInfo = [String: String]()
-        if let label = label {
-            userInfo["label"] = label
-        }
 
         if let label = label {
             userInfo["label"] = label

--- a/PeakOperation/Core/ConcurrentOperation.swift
+++ b/PeakOperation/Core/ConcurrentOperation.swift
@@ -38,7 +38,6 @@ open class ConcurrentOperation: Operation {
     internal var managesOwnProgress = false
     
     public var estimatedExecutionSeconds: TimeInSeconds = 1
-    public var label: String?
     
     @objc
     fileprivate dynamic var state: OperationState {
@@ -120,8 +119,8 @@ open class ConcurrentOperation: Operation {
     private func postNotification(_ notification: Notification.Name) {
         var userInfo = [String: String]()
 
-        if let label = label {
-            userInfo["label"] = label
+        if let name = name {
+            userInfo["name"] = name
         }
 
         if let queueName = OperationQueue.current?.name {
@@ -138,7 +137,7 @@ open class ConcurrentOperation: Operation {
     // MARK: - Public
     
     open override var description: String {
-        return "\(String(describing: type(of: self)))(label: '\(label ?? "nil")', state: \(state.rawValue))"
+        return "\(String(describing: type(of: self)))(name: '\(name ?? "nil")', state: \(state.rawValue))"
     }
     
     /// Override this method to perform your work. 

--- a/PeakOperation/Core/ConcurrentOperation.swift
+++ b/PeakOperation/Core/ConcurrentOperation.swift
@@ -23,8 +23,8 @@ fileprivate enum OperationState: Int {
 /// When your work is completed, call `finish()` to complete the operation.
 open class ConcurrentOperation: Operation {
     
-    static let operationWillStart = Notification.Name("PeakOperation.ConcurrentOperation.operationWillStart")
-    static let operationWillFinish = Notification.Name("PeakOperation.ConcurrentOperation.operationWillFinish")
+    public static let operationWillStart = Notification.Name("PeakOperation.ConcurrentOperation.operationWillStart")
+    public static let operationWillFinish = Notification.Name("PeakOperation.ConcurrentOperation.operationWillFinish")
 
     private var willStart: () -> Void = { }
     private var willFinish: () -> Void = { }

--- a/PeakOperation/Core/ConcurrentOperation.swift
+++ b/PeakOperation/Core/ConcurrentOperation.swift
@@ -140,6 +140,9 @@ open class ConcurrentOperation: Operation {
     
     // MARK: - Public
     
+    open override var description: String {
+        return "\(String(describing: type(of: self)))(label: '\(label ?? "nil")', state: \(state.rawValue))"
+    }
     
     /// Override this method to perform your work. 
     /// This will not be executed on a separate thread; it is your responsibiity to do so, if needed.

--- a/Unit Tests/Core/NotificationTests.swift
+++ b/Unit Tests/Core/NotificationTests.swift
@@ -60,18 +60,18 @@ class NotificationTests: XCTestCase {
     
     func testCustomOperationLabelIsSentInNotification() {
         let operation = BlockResultOperation { return "Hello" }
-        operation.label = "Doing some work..."
+        operation.name = "Doing some work..."
         operation.enqueue()
         
         expectation(forNotification: ConcurrentOperation.operationWillStart, object: nil, notificationCenter: .default) { notification in
-            let operationLabel = notification.userInfo?["label"] as! String
-            XCTAssertEqual(operationLabel, operation.label)
+            let operationLabel = notification.userInfo?["name"] as! String
+            XCTAssertEqual(operationLabel, operation.name)
             return true
         }
         
         expectation(forNotification: ConcurrentOperation.operationWillFinish, object: nil, notificationCenter: .default) { notification in
-            let operationLabel = notification.userInfo?["label"] as! String
-            XCTAssertEqual(operationLabel, operation.label)
+            let operationLabel = notification.userInfo?["name"] as! String
+            XCTAssertEqual(operationLabel, operation.name)
             return true
         }
         
@@ -80,7 +80,7 @@ class NotificationTests: XCTestCase {
     
     func testOperationIsSentInNotification() {
         let operation = BlockResultOperation { return "Hello" }
-        operation.label = "Doing some work..."
+        operation.name = "Doing some work..."
         operation.enqueue()
         
         expectation(forNotification: ConcurrentOperation.operationWillStart, object: nil, notificationCenter: .default) { notification in
@@ -100,10 +100,10 @@ class NotificationTests: XCTestCase {
 
     func testOperationHasNiceDescription() {
         let operation = BlockResultOperation { return "Hello" }
-        operation.label = "Doing some work..."
+        operation.name = "Doing some work..."
 
         let description = operation.description
         
-        XCTAssertEqual(description, "BlockResultOperation<String>(label: 'Doing some work...', state: 0)")
+        XCTAssertEqual(description, "BlockResultOperation<String>(name: 'Doing some work...', state: 0)")
     }
 }

--- a/Unit Tests/Core/NotificationTests.swift
+++ b/Unit Tests/Core/NotificationTests.swift
@@ -1,0 +1,101 @@
+//
+//  RetryTests.swift
+//  PeakOperation-iOSTests
+//
+//  Created by Sam Oakley on 27/02/2019.
+//  Copyright © 2019 3Squared. All rights reserved.
+//
+
+import XCTest
+#if os(iOS)
+@testable import PeakOperation_iOS
+#else
+@testable import PeakOperation_macOS
+#endif
+
+class NotificationTests: XCTestCase {
+    
+    func testWillStartNotificationIsSent() {
+        let queue = OperationQueue()
+        let operation = BlockResultOperation { return "Hello" }
+        operation.enqueue(on: queue)
+        
+        expectation(forNotification: ConcurrentOperation.operationWillStart, object: nil, notificationCenter: .default)
+        
+        waitForExpectations(timeout: 10)
+    }
+
+    func testWillFinishNotificationIsSent() {
+        let queue = OperationQueue()
+        let operation = BlockResultOperation { return "Hello" }
+        operation.enqueue(on: queue)
+        
+        expectation(forNotification: ConcurrentOperation.operationWillFinish, object: nil, notificationCenter: .default)
+        
+        waitForExpectations(timeout: 10)
+    }
+
+    func testNotificationContainsQueueName() {
+        let queue = OperationQueue()
+        queue.name = "NotificationTests.Queue"
+        
+        let operation = BlockResultOperation { return "Hello" }
+        operation.enqueue(on: queue)
+        
+        expectation(forNotification: ConcurrentOperation.operationWillStart, object: nil, notificationCenter: .default) { notification in
+            let currentQueueName = notification.userInfo?["queue"] as! String
+            XCTAssertEqual(currentQueueName, queue.name)
+            return true
+        }
+        
+        expectation(forNotification: ConcurrentOperation.operationWillFinish, object: nil, notificationCenter: .default) { notification in
+            let currentQueueName = notification.userInfo?["queue"] as! String
+            XCTAssertEqual(currentQueueName, queue.name)
+            return true
+        }
+        
+        waitForExpectations(timeout: 10)
+    }
+
+    
+    func testCustomOperationLabelIsSentInNotification() {
+        let operation = BlockResultOperation { return "Hello" }
+        operation.label = "Doing some work..."
+        operation.enqueue()
+        
+        expectation(forNotification: ConcurrentOperation.operationWillStart, object: nil, notificationCenter: .default) { notification in
+            let operationLabel = notification.userInfo?["label"] as! String
+            XCTAssertEqual(operationLabel, operation.label)
+            return true
+        }
+        
+        expectation(forNotification: ConcurrentOperation.operationWillFinish, object: nil, notificationCenter: .default) { notification in
+            let operationLabel = notification.userInfo?["label"] as! String
+            XCTAssertEqual(operationLabel, operation.label)
+            return true
+        }
+        
+        waitForExpectations(timeout: 10)
+    }
+    
+    func testOperationIsSentInNotification() {
+        let operation = BlockResultOperation { return "Hello" }
+        operation.label = "Doing some work..."
+        operation.enqueue()
+        
+        expectation(forNotification: ConcurrentOperation.operationWillStart, object: nil, notificationCenter: .default) { notification in
+            let object = notification.object as! ConcurrentOperation
+            XCTAssertEqual(object, operation)
+            return true
+        }
+        
+        expectation(forNotification: ConcurrentOperation.operationWillFinish, object: nil, notificationCenter: .default) { notification in
+            let object = notification.object as! ConcurrentOperation
+            XCTAssertEqual(object, operation)
+            return true
+        }
+        
+        waitForExpectations(timeout: 10)
+    }
+
+}

--- a/Unit Tests/Core/NotificationTests.swift
+++ b/Unit Tests/Core/NotificationTests.swift
@@ -98,4 +98,12 @@ class NotificationTests: XCTestCase {
         waitForExpectations(timeout: 10)
     }
 
+    func testOperationHasNiceDescription() {
+        let operation = BlockResultOperation { return "Hello" }
+        operation.label = "Doing some work..."
+
+        let description = operation.description
+        
+        XCTAssertEqual(description, "BlockResultOperation<String>(label: 'Doing some work...', state: 0)")
+    }
 }

--- a/Unit Tests/Core/ProgressTests.swift
+++ b/Unit Tests/Core/ProgressTests.swift
@@ -51,7 +51,6 @@ class ProgressTests: XCTestCase {
         waitForExpectations(timeout: 10)
         
         XCTAssertEqual(progress.fractionCompleted, 1)
-        print("Total Progress: \(progress.localizedAdditionalDescription!)")
     }
     
     func testSubclassWithDetailedOperationProgress() {
@@ -82,7 +81,6 @@ class ProgressTests: XCTestCase {
         
         XCTAssertEqual(progress.fractionCompleted, 1)
         XCTAssertEqual(progress.totalUnitCount, 11)
-        print("Total Progress: \(progress.localizedAdditionalDescription!)")
     }
     
     func testGroupOperationProgress() {
@@ -115,7 +113,6 @@ class ProgressTests: XCTestCase {
         
         XCTAssertEqual(progress.fractionCompleted, 1)
         XCTAssertEqual(progress.totalUnitCount, 1)
-        print("Total Progress: \(progress.localizedAdditionalDescription!)")
     }
     
     func testGroupOperationCollatingProgress() {
@@ -148,7 +145,6 @@ class ProgressTests: XCTestCase {
         
         XCTAssertEqual(progress.fractionCompleted, 1)
         XCTAssertEqual(progress.totalUnitCount, 2)
-        print("Total Progress: \(progress.localizedAdditionalDescription!)")
     }
     
     func testNestedGroupOperationsCollatingProgress() {
@@ -194,7 +190,6 @@ class ProgressTests: XCTestCase {
         
         XCTAssertEqual(progress.fractionCompleted, 1)
         XCTAssertEqual(progress.totalUnitCount, 6)
-        print("Total Progress: \(progress.localizedAdditionalDescription!)")
     }
 
 }


### PR DESCRIPTION
If you want to show progress, you can use the `overallProgress()` function on an operation. If you want to show a nice message for what is currently happening, then `NSProgress` doesn't help much since you can't set custom labels.

Instead, now a `Notification` is fired when an operation is about to start/finish. This, combined with a new `label` property, can let you get updates as operations are started and update a label/other indicator as needed.