### PR TITLE
Feature/base operation additions

### DIFF
--- a/PeakOperation/Core/ConcurrentOperation.swift
+++ b/PeakOperation/Core/ConcurrentOperation.swift
@@ -33,11 +33,11 @@ open class ConcurrentOperation: Operation {
     private var willFinish: () -> Void = { }
     private var didFinish: () -> Void = { }
 
-    fileprivate let stateQueue = DispatchQueue(label: "PeakOperation.ConcurrentOperation.StateQueue", attributes: .concurrent)
-    fileprivate var rawState = OperationState.ready
+    private let stateQueue = DispatchQueue(label: "PeakOperation.ConcurrentOperation.StateQueue", attributes: .concurrent)
+    private var rawState = OperationState.ready
     
-    public var startDate: Date?
-    public var finishDate: Date?
+    public private(set) var startDate: Date?
+    public private(set) var finishDate: Date?
     
     public var executionTime: TimeInterval {
         guard let startDate = startDate else { return 0 }
@@ -55,7 +55,7 @@ open class ConcurrentOperation: Operation {
     }()
     
     @objc
-    fileprivate dynamic var state: OperationState {
+    private dynamic var state: OperationState {
         get {
             return stateQueue.sync(execute: { rawState })
         }
@@ -81,17 +81,17 @@ open class ConcurrentOperation: Operation {
     // MARK: - NSObject
     
     @objc
-    fileprivate dynamic class func keyPathsForValuesAffectingIsReady() -> Set<String> {
+    private dynamic class func keyPathsForValuesAffectingIsReady() -> Set<String> {
         return ["state"]
     }
     
     @objc
-    fileprivate dynamic class func keyPathsForValuesAffectingIsExecuting() -> Set<String> {
+    private dynamic class func keyPathsForValuesAffectingIsExecuting() -> Set<String> {
         return ["state"]
     }
     
     @objc
-    fileprivate dynamic class func keyPathsForValuesAffectingIsFinished() -> Set<String> {
+    private dynamic class func keyPathsForValuesAffectingIsFinished() -> Set<String> {
         return ["state"]
     }
     

--- a/PeakOperation/Core/ConcurrentOperation.swift
+++ b/PeakOperation/Core/ConcurrentOperation.swift
@@ -24,18 +24,35 @@ fileprivate enum OperationState: Int {
 open class ConcurrentOperation: Operation {
     
     public static let operationWillStart = Notification.Name("PeakOperation.ConcurrentOperation.operationWillStart")
+    public static let operationDidStart = Notification.Name("PeakOperation.ConcurrentOperation.operationDidStart")
     public static let operationWillFinish = Notification.Name("PeakOperation.ConcurrentOperation.operationWillFinish")
+    public static let operationDidFinish = Notification.Name("PeakOperation.ConcurrentOperation.operationDidFinish")
 
     private var willStart: () -> Void = { }
+    private var didStart: () -> Void = { }
     private var willFinish: () -> Void = { }
-    
-    public typealias TimeInSeconds = Int64
-    
+    private var didFinish: () -> Void = { }
+
     fileprivate let stateQueue = DispatchQueue(label: "PeakOperation.ConcurrentOperation.StateQueue", attributes: .concurrent)
     fileprivate var rawState = OperationState.ready
     
+    public var startDate: Date?
+    public var finishDate: Date?
+    
+    public var executionTime: TimeInterval {
+        guard let startDate = startDate else { return 0 }
+        let endDate = finishDate ?? Date()
+        return endDate.timeIntervalSince(startDate)
+    }
+    
     public var progress = Progress(totalUnitCount: 100)
     internal var managesOwnProgress = false
+    
+    public lazy var internalQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "PeakOperation.ConcurrentOperation.InternalQueue"
+        return queue
+    }()
     
     @objc
     fileprivate dynamic var state: OperationState {
@@ -111,6 +128,11 @@ open class ConcurrentOperation: Operation {
         postNotification(ConcurrentOperation.operationWillStart)
         willStart()
         state = .executing
+        
+        startDate = Date()
+        postNotification(ConcurrentOperation.operationDidStart)
+        didStart()
+        
         execute()
     }
     
@@ -138,6 +160,11 @@ open class ConcurrentOperation: Operation {
         return "\(String(describing: type(of: self)))(name: '\(name ?? "nil")', state: \(state.rawValue))"
     }
     
+    open override func cancel() {
+        internalQueue.cancelAllOperations()
+        super.cancel()
+    }
+    
     /// Override this method to perform your work. 
     /// This will not be executed on a separate thread; it is your responsibiity to do so, if needed.
     ///
@@ -151,6 +178,10 @@ open class ConcurrentOperation: Operation {
         postNotification(ConcurrentOperation.operationWillFinish)
         willFinish()
         state = .finished
+        
+        finishDate = Date()
+        postNotification(ConcurrentOperation.operationDidFinish)
+        didFinish()
     }
     
     /// Add a block to be called just before an operation begins executing.
@@ -165,13 +196,36 @@ open class ConcurrentOperation: Operation {
         }
     }
     
-    /// Add a block to be called after execution has finished.
+    /// Add a block to be called just after an operation begins executing.
+    ///
+    /// - Parameter block
+    public func addDidStartBlock(block: @escaping () -> Void) {
+        let existing = didStart
+        didStart = {
+            existing()
+            block()
+        }
+    }
+    
+    /// Add a block to be called before finishing.
     /// Any output from an operation should be set by the time the block is called.
     ///
     /// - Parameter block
     public func addWillFinishBlock(block: @escaping () -> Void) {
         let existing = willFinish
         willFinish = {
+            existing()
+            block()
+        }
+    }
+    
+    /// Add a block to be called after finishing.
+    /// Any output from an operation should be set by the time the block is called.
+    ///
+    /// - Parameter block
+    public func addDidFinishBlock(block: @escaping () -> Void) {
+        let existing = didFinish
+        didFinish = {
             existing()
             block()
         }

--- a/PeakOperation/Core/GroupChainOperation.swift
+++ b/PeakOperation/Core/GroupChainOperation.swift
@@ -19,12 +19,6 @@ open class GroupChainOperation: ConcurrentOperation, ProducesResult, ConsumesRes
     public var output: Result<Void, Error> = Result { throw ResultError.noResult }
     public var input: Result<Void, Error> = Result { }
     
-    fileprivate lazy var internalQueue: OperationQueue = {
-        let queue = OperationQueue()
-        queue.name = "GroupOperation.InternalQueue"
-        return queue
-    }()
-
     fileprivate let operation: Operation
     
     /// Create a new `GroupChainOperation`.
@@ -60,11 +54,6 @@ open class GroupChainOperation: ConcurrentOperation, ProducesResult, ConsumesRes
             output = Result { throw error }
             finish()
         }
-    }
-    
-    open override func cancel() {
-        internalQueue.cancelAllOperations()
-        super.cancel()
     }
 }
 

--- a/Unit Tests/Core/NotificationTests.swift
+++ b/Unit Tests/Core/NotificationTests.swift
@@ -24,6 +24,16 @@ class NotificationTests: XCTestCase {
         
         waitForExpectations(timeout: 10)
     }
+    
+    func testDidStartNotificationIsSent() {
+        let queue = OperationQueue()
+        let operation = BlockResultOperation { return "Hello" }
+        operation.enqueue(on: queue)
+        
+        expectation(forNotification: ConcurrentOperation.operationDidStart, object: nil, notificationCenter: .default)
+        
+        waitForExpectations(timeout: 10)
+    }
 
     func testWillFinishNotificationIsSent() {
         let queue = OperationQueue()
@@ -31,6 +41,16 @@ class NotificationTests: XCTestCase {
         operation.enqueue(on: queue)
         
         expectation(forNotification: ConcurrentOperation.operationWillFinish, object: nil, notificationCenter: .default)
+        
+        waitForExpectations(timeout: 10)
+    }
+    
+    func testDidFinishNotificationIsSent() {
+        let queue = OperationQueue()
+        let operation = BlockResultOperation { return "Hello" }
+        operation.enqueue(on: queue)
+        
+        expectation(forNotification: ConcurrentOperation.operationDidFinish, object: nil, notificationCenter: .default)
         
         waitForExpectations(timeout: 10)
     }

--- a/Unit Tests/Core/NotificationTests.swift
+++ b/Unit Tests/Core/NotificationTests.swift
@@ -168,6 +168,7 @@ class NotificationTests: XCTestCase {
             let object = notification.object as! ConcurrentOperation
             XCTAssertNil(object.startDate)
             XCTAssertNil(object.finishDate)
+            XCTAssertEqual(operation.executionTime, 0)
             return true
         }
         
@@ -175,6 +176,7 @@ class NotificationTests: XCTestCase {
             let object = notification.object as! ConcurrentOperation
             XCTAssertNotNil(object.startDate)
             XCTAssertNil(object.finishDate)
+            XCTAssertGreaterThan(operation.executionTime, 0)
             return true
         }
         
@@ -182,6 +184,7 @@ class NotificationTests: XCTestCase {
             let object = notification.object as! ConcurrentOperation
             XCTAssertNotNil(object.startDate)
             XCTAssertNil(object.finishDate)
+            XCTAssertGreaterThan(operation.executionTime, 0)
             return true
         }
         
@@ -189,6 +192,7 @@ class NotificationTests: XCTestCase {
             let object = notification.object as! ConcurrentOperation
             XCTAssertNotNil(object.startDate)
             XCTAssertNotNil(object.finishDate)
+            XCTAssertEqual(operation.executionTime, operation.finishDate!.timeIntervalSince(operation.startDate!))
             return true
         }
         
@@ -207,24 +211,28 @@ class NotificationTests: XCTestCase {
         operation.addWillStartBlock {
             XCTAssertNil(operation.startDate)
             XCTAssertNil(operation.finishDate)
+            XCTAssertEqual(operation.executionTime, 0)
             expect.fulfill()
         }
         
         operation.addDidStartBlock {
             XCTAssertNotNil(operation.startDate)
             XCTAssertNil(operation.finishDate)
+            XCTAssertGreaterThan(operation.executionTime, 0)
             expect.fulfill()
         }
         
         operation.addWillFinishBlock {
             XCTAssertNotNil(operation.startDate)
             XCTAssertNil(operation.finishDate)
+            XCTAssertGreaterThan(operation.executionTime, 0)
             expect.fulfill()
         }
         
         operation.addDidFinishBlock {
             XCTAssertNotNil(operation.startDate)
             XCTAssertNotNil(operation.finishDate)
+            XCTAssertEqual(operation.executionTime, operation.finishDate!.timeIntervalSince(operation.startDate!))
             expect.fulfill()
         }
         


### PR DESCRIPTION
Adds the following to the base `ConcurrentOperation`:

1. Ability to add `didStart` and `didFinish` blocks
2. Ability to listen to `didStart` and `didFinish` notifications
3. Adds a `startDate` and `finishDate` property and `executionTime` computed property]
4. Adds lazy `internalQueue` property (and removes from `GroupChainOperation`)