### PR TITLE
Add @available attributes for group chaining operations

### DIFF
--- a/Sources/PeakOperation/GroupChainOperation.swift
+++ b/Sources/PeakOperation/GroupChainOperation.swift
@@ -14,6 +14,7 @@ import Foundation
 /// that this operation can produce a result.
 /// If any operation in the group fails, the overall group operation will have a failure result.
 /// If it succeeds, it will be a successful result but contain no object.
+@available(iOS 9, macOS 10.11, *)
 open class GroupChainOperation: ConcurrentOperation, ProducesResult, ConsumesResult {
     
     public var output: Result<Void, Error> = Result { throw ResultError.noResult }
@@ -57,6 +58,7 @@ open class GroupChainOperation: ConcurrentOperation, ProducesResult, ConsumesRes
     }
 }
 
+@available(iOS 9, macOS 10.11, *)
 extension ProducesResult where Self: ConcurrentOperation {
     
     /// Add the operation and its chain to a group.

--- a/Sources/PeakOperation/Operation+Queue.swift
+++ b/Sources/PeakOperation/Operation+Queue.swift
@@ -38,6 +38,7 @@ extension Operation {
         return operation
     }
     
+    @available(iOS 9, macOS 10.11, *)
     public func chainProgress() -> Progress {
         let chain = operationChain.compactMap { $0 as? ConcurrentOperation }
         let totalProgress = Progress(totalUnitCount: 100)
@@ -80,6 +81,7 @@ extension ConcurrentOperation {
     ///
     /// - Parameter queue: The queue to use. If not provided, a new one is made (optional).
     /// - Returns: The progress of the operation chain's execution.
+    @available(iOS 9, macOS 10.11, *)
     public func enqueueWithProgress(on queue: OperationQueue = OperationQueue()) -> Progress {
         enqueue(on: queue)
         return chainProgress()
@@ -93,6 +95,7 @@ extension ProducesResult where Self: ConcurrentOperation {
     ///
     /// - Parameter queue: The queue to use. If not provided, a new one is made (optional).
     /// - Returns: The progress of the operation chain's execution.
+    @available(iOS 9, macOS 10.11, *)
     public func enqueueWithProgress(on queue: OperationQueue = OperationQueue(), completion: @escaping (Result<Output, Error>) -> Void) -> Progress {
         addResultBlock(block: completion)
         enqueue(on: queue)


### PR DESCRIPTION
Wraps group operation methods with `@available(iOS 9, macOS 10.11, *)` flags where `addChild(_:withPendingUnitCount:)` is only available on macOS `10.11` and higher.